### PR TITLE
Default namespace and fix other namespaces

### DIFF
--- a/se4rs/test.xml
+++ b/se4rs/test.xml
@@ -19,6 +19,7 @@ which is our proposed execution-description vocabulary, http://example.org/execu
          xmlns:doco="http://purl.org/spar/doco/2015-07-03"
          xmlns:prov="http://www.w3.org/TR/2013/PR-prov-o-20130312/"
          xmlns:wfdesc="http://purl.org/wf4ever/wfdesc#"
+         xmlns="http://example.org/execution-description/1.0/"
          xml:lang="en"
          >
 

--- a/se4rs/test.xml
+++ b/se4rs/test.xml
@@ -98,11 +98,11 @@ which is our proposed execution-description vocabulary, http://example.org/execu
         <wikibase:Statement>
           <rdf:Description>
             <!-- Q12156 refers to malaria -->
-            <subject rdf:resource="https://www.wikidata.org/entity/Q12156" />
+            <rdf:subject rdf:resource="https://www.wikidata.org/entity/Q12156" />
             <!-- P1060 refers to disease transmission process (read: "is transmitted by") -->
-            <predicate rdf:resource="http://www.wikidata.org/prop/P1060" />
+            <rdf:predicate rdf:resource="http://www.wikidata.org/prop/P1060" />
             <!-- Q15304532 refers to mosquitoes -->
-            <object rdf:resource="https://www.wikidata.org/entity/Q15304532" />
+            <rdf:object rdf:resource="https://www.wikidata.org/entity/Q15304532" />
           </rdf:Description>
         </wikibase:Statement>
       </cito:supports>
@@ -120,10 +120,15 @@ which is our proposed execution-description vocabulary, http://example.org/execu
   </process>
 
   <!-- Here, we add parameters to the command -->
-  <process rdfs:label="example-of-parameters">
+  <wfdesc:process rdfs:label="example-of-parameters">
     <!-- These might be template filled like so: -->
     <command>./generate ${max_resolution} ${rounds}</command>
-    <wfdesc:Parameter rdfs:label="max_resolution" />
+    <wfdesc:hasInput>
+           <wfdesc:Parameter rdfs:label="max_resolution" />
+    </wfdesc:hasInput>
+    <wfdesc:hasInput>
+           <wfdesc:Parameter rdfs:label="rounds" />
+    </wfdesc:hasInput>           
   </process>
 
 </rdf:RDF>

--- a/se4rs/test.xml
+++ b/se4rs/test.xml
@@ -15,11 +15,12 @@ which is our proposed execution-description vocabulary, http://example.org/execu
          xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
          xmlns:dc="http://purl.org/dc/elements/1.1/"
          xmlns:wikibase="http://wikiba.se/ontology#"
-         xmlns:cito="http://purl.org/spar/cito"
-         xmlns:doco="http://purl.org/spar/doco/2015-07-03"
-         xmlns:prov="http://www.w3.org/TR/2013/PR-prov-o-20130312/"
+         xmlns:cito="http://purl.org/spar/cito/"
+         xmlns:doco="http://purl.org/spar/doco/"
+         xmlns:prov="http://www.w3.org/ns/prov#role"
          xmlns:wfdesc="http://purl.org/wf4ever/wfdesc#"
-         xmlns="http://example.org/execution-description/1.0/"
+         xmlns="http://example.org/execution-description/"
+         xml:base="https://example.com/software-experiment-23#"
          xml:lang="en"
          >
 
@@ -119,7 +120,7 @@ which is our proposed execution-description vocabulary, http://example.org/execu
   </process>
 
   <!-- Here, we add parameters to the command -->
-  <process rdf:label="example-of-parameters">
+  <process rdfs:label="example-of-parameters">
     <!-- These might be template filled like so: -->
     <command>./generate ${max_resolution} ${rounds}</command>
     <wfdesc:Parameter rdfs:label="max_resolution" />


### PR DESCRIPTION
so that terms like `process` are in the example vocabulary